### PR TITLE
修复在Linux下面无法读取时间，导致无法启动

### DIFF
--- a/DyberPet/utils.py
+++ b/DyberPet/utils.py
@@ -3,6 +3,7 @@ import os
 import time
 from datetime import datetime
 import textwrap as tr
+import locale
 
 
 
@@ -84,7 +85,9 @@ def get_child_folder(parentFolder, relative=False):
 
 
 
+
 def get_file_time(filePath):
+    locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
     ct = os.path.getctime(filePath)
     ct = time.strptime(time.ctime(ct))
     fileTime = datetime(year=int(ct[0]), month=int(ct[1]), day=int(ct[2]),


### PR DESCRIPTION
设置本地时间设定，由于不同系统间的地区编码可能存在差异，适用windows ,linux使用本地时间的地区设定。 方法来自于
https://blog.csdn.net/weixin_41341221/article/details/102890465