### PR TITLE
1.8 Todo

### DIFF
--- a/DyberPet/DyberPet.py
+++ b/DyberPet/DyberPet.py
@@ -901,19 +901,13 @@ class PetWidget(QWidget):
     def trigger_event(self, event_type: EventType, priority: EventPriority, event_data: dict):
         """
         通用事件触发函数
-        
+
         Args:
             event_type: 事件类型
             priority: 事件优先级
-            event_data: 事件数据
+            event_data: 事件数据（纯业务数据，不包含timestamp和pet_status）
         """
-        # 添加宠物状态和时间戳
-        event_data.update({
-            "timestamp": time.time(),
-            "pet_status": self.get_pet_status()
-        })
-        
-        # 发送到大模型请求管理器
+        # 直接发送到大模型请求管理器，让LLMRequestManager统一添加时间戳和宠物状态
         self.add_llm_event.emit({"event_type":event_type, "priority":priority, "event_data":event_data})
 
     def _process_pending_clicks(self):
@@ -932,15 +926,13 @@ class PetWidget(QWidget):
         click_intensity = round(0.4 * frequency_factor + 0.6 * duration_factor, 2)
 
         print(f"[批量点击力度] 次数:{click_count}, 平均长按:{avg_duration:.2f}秒, 力度值:{click_intensity:.2f}")
-        # 构建事件数据
+        # 构建事件数据（移除timestamp，由LLMRequestManager统一添加）
         event_data = {
             "message": f"用户点击了你，力度值为{click_intensity}(0-1范围内,1为最大力度)",
-            "timestamp": time.time(),
             "description": "用户点击交互",
             "intensity": click_intensity,
-
         }
-        
+
          # 使用通用事件触发函数
         self.trigger_event(EventType.USER_INTERACTION, EventPriority.HIGH, event_data)
 


### PR DESCRIPTION
主要操作总结
1. 在LLMRequestManager中创建统一的事件数据构建方法
新增_create_standard_event_data方法：统一创建标准格式的事件数据
定义标准Schema：包含event_id、event_type、priority、timestamp、pet_status、context六个字段
清理重复字段
2. 重构事件接收方法使用统一格式
修改add_event_from_petwidget方法：接收PetWidget的事件数据，转换为标准格式后处理
修改add_event_from_chatai方法：接收ChatAI的消息，构建标准格式的用户交互事件
新增_add_standard_event方法
修改_process_high_priority_event方法：为每个context创建标准事件数据
统一时间戳和宠物状态：确保同一批次的事件使用相同的时间戳和宠物状态快照
清理重复字段
3. 移除PetWidget中的重复数据添加逻辑
简化trigger_event方法：移除手动添加timestamp和pet_status的代码，让LLMRequestManager统一处理
修改_process_pending_clicks方法：移除事件数据中的重复timestamp字段